### PR TITLE
Add command for pretty printed selection evaluation

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "visual:clojure",
     "description": "Clojure and ClojureScript support",
     "icon": "assets/icon.png",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "publisher": "stiansivertsen",
     "author": {
         "name": "Stian Sivertsen",
@@ -70,6 +70,11 @@
                 "category": "visualclojure"
             },
             {
+                "command": "visualclojure.evaluateSelectionPrettyPrint",
+                "title": "evaluate selection or current form, and pretty print",
+                "category": "visualclojure"
+            },
+            {
                 "command": "visualclojure.evaluateFile",
                 "title": "evaluate current file",
                 "category": "visualclojure"
@@ -95,6 +100,11 @@
                 "command": "visualclojure.evaluateSelection",
                 "key": "alt+v e",
                 "mac": "alt+v e"
+            },
+            {
+                "command": "visualclojure.evaluateSelectionPrettyPrint",
+                "key": "alt+v p",
+                "mac": "alt+v p"
             },
             {
                 "command": "visualclojure.evaluateFile",

--- a/src/extension.js
+++ b/src/extension.js
@@ -54,6 +54,7 @@ function activate(context) {
     context.subscriptions.push(vscode.commands.registerCommand('visualclojure.reconnect', connector.reconnect));
     context.subscriptions.push(vscode.commands.registerCommand('visualclojure.evaluateFile', EvaluateMiddleWare.evaluateFile));
     context.subscriptions.push(vscode.commands.registerCommand('visualclojure.evaluateSelection', EvaluateMiddleWare.evaluateSelection));
+    context.subscriptions.push(vscode.commands.registerCommand('visualclojure.evaluateSelectionPrettyPrint', EvaluateMiddleWare.evaluateSelectionPrettyPrint));
     context.subscriptions.push(vscode.commands.registerCommand('visualclojure.lintFile', LintMiddleWare.lintDocument));
 
     // PROVIDERS

--- a/src/repl/middleware/evaluate.js
+++ b/src/repl/middleware/evaluate.js
@@ -12,13 +12,16 @@ const {
     logError,
     ERROR_TYPE,
     getContentToNextBracket,
+    getPrettyPrintCode,
     getContentToPreviousBracket
 } = require('../../utilities');
 
-function evaluateSelection(document = {}) {
+function evaluateSelection(document = {}, options = {}) {
     let current = state.deref(),
         chan = current.get('outputChannel'),
+        //doc = '(pprint ' + getDocument(document) + ')',
         doc = getDocument(document),
+        pprint = options.pprint || false,
         session = current.get(getFileType(doc));
 
     chan.clear();
@@ -72,7 +75,7 @@ function evaluateSelection(document = {}) {
             let evalClient = null;
             new Promise((resolve, reject) => {
                 evalClient = repl.create().once('connect', () => {
-                    let msg = message.evaluate(session, getNamespace(doc.getText()), code);
+                    let msg = message.evaluate(session, getNamespace(doc.getText()), (pprint ? getPrettyPrintCode(code) : code));
                     evalClient.send(msg, (result) => {
                         let exceptions = _.some(result, "ex"),
                             errors = _.some(result, "err");
@@ -93,6 +96,10 @@ function evaluateSelection(document = {}) {
             });
         }
     }
+};
+
+function evaluateSelectionPrettyPrint(document = {}, options = {}) {
+    evaluateSelection(document, Object.assign({}, options, { pprint: true }));
 };
 
 function evaluateFile(document = {}) {
@@ -135,4 +142,5 @@ function evaluateFile(document = {}) {
 module.exports = {
     evaluateFile,
     evaluateSelection,
+    evaluateSelectionPrettyPrint,
 };

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -141,6 +141,15 @@ function getContentToPreviousBracket(block) {
     return [currPos, block.substr(currPos + 1, block.length)];
 };
 
+function getPrettyPrintCode(code) {
+    let isCljs = state.deref().get('cljs');
+    if (isCljs) {
+        return "(cljs.pprint/pprint " + code + ")";
+    } else {
+        return "(clojure.pprint/pprint " + code + ")";
+    }
+};
+
 // ERROR HELPERS
 const ERROR_TYPE = {
     WARNING: "warning",
@@ -246,6 +255,7 @@ module.exports = {
     getFileType,
     getFileName,
     getContentToNextBracket,
+    getPrettyPrintCode,
     getContentToPreviousBracket,
     specialWords,
     ERROR_TYPE,


### PR DESCRIPTION
Press `alt+v, p`, and pprint will be used when logging the result of the
evaluation. Sometimes useful for making sense of large data structures.